### PR TITLE
Add cross-platform build scripts

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,47 @@
+#!/usr/bin/env pwsh
+
+# Build, lint, test, and run the artifact
+
+# Run C++ linter if available
+if (Get-Command cpplint -ErrorAction SilentlyContinue) {
+    Write-Host "Running cpplint..."
+    cpplint src/*.cpp src/*.h | Out-Default
+} else {
+    Write-Host "cpplint not found; skipping lint."
+}
+
+# Build the project
+Write-Host "Building project..."
+try {
+    make
+} catch {
+    Write-Error "Build failed."
+    exit 1
+}
+
+# Run tests if a test directory exists
+if (Test-Path tests) {
+    Write-Host "Running tests..."
+    if (Get-Command pytest -ErrorAction SilentlyContinue) {
+        try {
+            pytest | Out-Default
+        } catch {
+            Write-Warning "Tests failed."
+        }
+    } else {
+        Write-Host "pytest not found; skipping tests."
+    }
+} else {
+    Write-Host "No tests to run."
+}
+
+# Execute the resulting binary if it exists
+if (Test-Path ./mygit) {
+    Write-Host "Running artifact..."
+    ./mygit --help
+} elseif (Test-Path ./mygit.exe) {
+    Write-Host "Running artifact..."
+    ./mygit.exe --help
+} else {
+    Write-Host "Built artifact not found."
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Build, lint, test, and run the artifact
+
+# Run C++ linter if available
+if command -v cpplint >/dev/null 2>&1; then
+  echo "Running cpplint..."
+  cpplint src/*.cpp src/*.h || true
+else
+  echo "cpplint not found; skipping lint."
+fi
+
+# Build the project
+echo "Building project..."
+if ! make; then
+  echo "Build failed." >&2
+  exit 1
+fi
+
+# Run tests if a test directory exists
+if [ -d tests ]; then
+  echo "Running tests..."
+  if command -v pytest >/dev/null 2>&1; then
+    pytest || echo "Tests failed." >&2
+  else
+    echo "pytest not found; skipping tests." >&2
+  fi
+else
+  echo "No tests to run."
+fi
+
+# Execute the resulting binary if it exists
+if [ -x ./mygit ]; then
+  echo "Running artifact..."
+  ./mygit --help || true
+elif [ -f ./mygit.exe ]; then
+  echo "Running artifact..."
+  ./mygit.exe --help || true
+else
+  echo "Built artifact not found."
+fi


### PR DESCRIPTION
## Summary
- add `run.sh` script to lint, build, test and run the program
- add `run.ps1` with the same behaviour for Windows

## Testing
- `cpplint src/*.cpp src/*.h`
- `make` *(fails: conversion from vector to string)*
- `No tests to run`
